### PR TITLE
pass event through to callback, fixes #13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "use-key-hook",
-  "version": "1.0.6",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/__test__/index.test.js
+++ b/src/__test__/index.test.js
@@ -42,7 +42,7 @@ describe('events', () => {
       code: 'ArrowUp'
     });
     fireEvent(container, keyDownEvent);
-    expect(callback).toHaveBeenCalledWith(38);
+    expect(callback).toHaveBeenCalledWith(38, keyDownEvent);
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
@@ -57,7 +57,7 @@ describe('events', () => {
       code: 'ArrowUp'
     });
     fireEvent(container, keyUpEvent);
-    expect(callback).toHaveBeenCalledWith(38);
+    expect(callback).toHaveBeenCalledWith(38, keyUpEvent);
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
@@ -72,7 +72,7 @@ describe('events', () => {
       code: 'ArrowUp'
     });
     fireEvent(container, keyPressEvent);
-    expect(callback).toHaveBeenCalledWith(38);
+    expect(callback).toHaveBeenCalledWith(38, keyPressEvent);
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
@@ -87,7 +87,7 @@ describe('events', () => {
       code: 'ArrowUp'
     });
     fireEvent(container, keyDownEvent);
-    expect(callback).not.toHaveBeenCalledWith(38);
+    expect(callback).not.toHaveBeenCalledWith(38, keyDownEvent);
     expect(callback).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ const useKey = (callback, { detectKeys = [], keyevent = 'keydown' } = {}, { depe
 
   const handleEvent = event => {
     const asciiCode = getAsciiCode(event);
-    return onKeyPress(asciiCode, callback, allowedKeys);
+    return onKeyPress(asciiCode, callback, allowedKeys, event);
   };
 
   useEffect(() => {

--- a/src/keys.js
+++ b/src/keys.js
@@ -6,9 +6,9 @@ const isKeyFromGivenList = (keyCode, allowedKeys = []) => {
   }
   return false;
 };
-const onKeyPress = (currentKeyCode, callback, allowedKeys) => {
+const onKeyPress = (currentKeyCode, callback, allowedKeys, event) => {
   if (isKeyFromGivenList(currentKeyCode, allowedKeys)) {
-    callback(currentKeyCode);
+    callback(currentKeyCode, event);
   }
 };
 


### PR DESCRIPTION
This PR exposes the key event to the callback so it can be used for cases such as `event.preventDefault()`.

This is a non-breaking change.